### PR TITLE
removed comma which will make `craft project-config/apply` choke

### DIFF
--- a/src/Volume.php
+++ b/src/Volume.php
@@ -254,7 +254,7 @@ class Volume extends FlysystemVolume
             'version' => 'latest',
             'credentials' => new Credentials(
                 $keyId,
-                $secret,
+                $secret
             ),
         ];
 


### PR DESCRIPTION
Ran into this when attempting `craft project-config/apply`. From `console.log`:

[-][-][-][error][ParseError] ParseError: syntax error, unexpected ')' in /var/www/guuu.org/site/vendor/mwikala/linode-s3/src/Volume.php:258