### PR TITLE
fseek(): stream does not support seeking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 composer.lock
+.idea/

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "craftcms/cms": "^3.1.0",
-        "league/flysystem-aws-s3-v3": "^1.0.13"
+        "league/flysystem-aws-s3-v3": "^1.0.28"
     },
     "autoload": {
         "psr-4": {

--- a/src/Volume.php
+++ b/src/Volume.php
@@ -188,7 +188,7 @@ class Volume extends FlysystemVolume
 
         $client = static::client($config);
 
-        return new AwsS3Adapter($client, $this->getBucket(), $this->getSubfolder());
+        return new AwsS3Adapter($client, $this->getBucket(), $this->getSubfolder(), [], false);
     }
 
     /**


### PR DESCRIPTION
I ran into an issue with a client being unable to download assets from their linode object storage through the CMS. On download the website was giving a 500 error with a craft error page stating: `fseek(): stream does not support seeking`

Following along the fix for this issue on the aws-s3 Craft CMS plugin: https://github.com/craftcms/aws-s3/pull/95

Set the `streamReads` argument to false in the `Volume.php` file. I also bumped up the `league/flysystem-aws-s3-v3` version requirement from `^1.0.13` to `^1.0.28` this was more to keep in line with what they did on the aws-s3 plugin.