### PR TITLE
Add support for Craft 4 by migrating to the new Filesystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 .idea/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.0 - 2022-07-25
+- Added support for Craft 4.
+
 ## 1.0.3 - 2021-01-15
 - Fixed a bug where you received a 500 when trying to download assets from the Bucket
 

--- a/README.md
+++ b/README.md
@@ -59,24 +59,6 @@ LINODE_S3_BUCKET=
 LINODE_S3_BUCKET_URL=
 ```
 
-You can also overwrite the settings of a volume using a `config/volumes.php` file. That would look something like this:
-
-```php
-<?php
-
-return [
-    'linodeOSVolumeHandle' => [
-        'hasUrls' => true,
-        'url' => getenv('LINODE_S3_BUCKET_URL'),
-        'keyId' => getenv('LINODE_S3_ACCESS_KEY'),
-        'secret' => getenv('LINODE_S3_SECRET'),
-        'endpoint' => getenv('LINODE_S3_ENDPOINT'),
-        'region' => getenv('LINODE_S3_REGION'),
-        'bucket' => getenv('LINODE_S3_BUCKET')
-    ],
-];
-```
-
 ## License & Support
 
 This plugin is released under the [MIT license](./LICENSE.md), meaning you can do whatever you please with it.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ composer require mwikala/linode-s3
 
 ## Setup
 
-To create a new asset volume for your Amazon S3 bucket, go to Settings → Assets, create a new volume, and set the Volume Type setting to “Linode S3”.
+To create a new asset file system for your Amazon S3 bucket, go to Settings → Filesystems, create a new filesystem, and set the Filesystem Type setting to “Linode S3”.
 
 ## Environment Variables
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "support": {
-        "email": "support@mwikala.co.uk",
+        "email": "hello@mwikala.co.uk",
         "issues": "https://github.com/mwikala/linode-s3/issues?state=open",
         "source": "https://github.com/mwikala/linode-s3",
         "docs": "https://github.com/mwikala/linode-s3/blob/master/README.md",

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "mwikala/linode-s3",
     "description": "This plugin provides Linode Object Storage integration for Craft CMS",
     "type": "craft-plugin",
+    "version": "2.0.0",
     "keywords": [
         "aws",
         "assets",
@@ -11,13 +12,14 @@
         "s3",
         "volumes",
         "filesystems",
-        "file system"
+        "file system",
+        "flysystem"
     ],
     "license": "MIT",
     "authors": [
         {
             "name": "Mwikala Kangwa",
-            "homepage": "http://mwikala.com/"
+            "homepage": "https://mwikala.com/"
         }
     ],
     "support": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,9 @@
         "object",
         "storage",
         "s3",
-        "volumes"
+        "volumes",
+        "filesystems",
+        "file system"
     ],
     "license": "MIT",
     "authors": [
@@ -26,8 +28,10 @@
         "rss": "https://github.com/mwikala/linode-s3/commits/master.atom"
     },
     "require": {
-        "craftcms/cms": "^3.1.0",
-        "league/flysystem-aws-s3-v3": "^1.0.28"
+        "php": "^8.0",
+        "craftcms/cms": "^4.0.0-beta.4",
+        "craftcms/flysystem": "^1.0.0-beta.2",
+        "league/flysystem-aws-s3-v3": "^3.0.0"
     },
     "autoload": {
         "psr-4": {
@@ -37,6 +41,18 @@
     "extra": {
         "name": "Linode Object Storage",
         "handle": "linode-s3",
+        "schemaVersion": "2.0.0",
         "documentationUrl": "https://github.com/mwikala/linode-s3/blob/master/README.md"
+    },
+    "config": {
+        "allow-plugins": {
+            "yiisoft/yii2-composer": true,
+            "craftcms/plugin-installer": true
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "require-dev": {
+        "craftcms/rector": "dev-main"
     }
 }

--- a/src/Fs.php
+++ b/src/Fs.php
@@ -16,11 +16,11 @@ use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
 use craft\behaviors\EnvAttributeParserBehavior;
 
 /**
- * Class Volume
+ * Class Fs
  *
  * @property mixed $settingsHtml
  * @property string $rootUrl
- * @author Mwikala Kangwa <support@mwikala.co.uk>
+ * @author Mwikala Kangwa <hello@mwikala.co.uk>
  * @since 1.0
  */
 class Fs extends FlysystemFs

--- a/src/Fs.php
+++ b/src/Fs.php
@@ -2,27 +2,28 @@
 
 namespace mwikala\linodes3;
 
-use Aws\Credentials\Credentials;
-use Aws\Handler\GuzzleV6\GuzzleHandler;
-use Aws\S3\Exception\S3Exception;
-use Aws\S3\S3Client;
-
 use Craft;
-use craft\base\FlysystemVolume;
-use craft\helpers\Assets;
-use craft\helpers\DateTimeHelper;
 use DateTime;
-use League\Flysystem\AwsS3v3\AwsS3Adapter;
+use Aws\S3\S3Client;
+use craft\helpers\App;
+use craft\helpers\Assets;
+use Aws\Credentials\Credentials;
+use craft\helpers\DateTimeHelper;
+use craft\flysystem\base\FlysystemFs;
+use Aws\Handler\GuzzleV6\GuzzleHandler;
+use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
+use craft\behaviors\EnvAttributeParserBehavior;
 
 /**
  * Class Volume
- * 
+ *
  * @property mixed $settingsHtml
  * @property string $rootUrl
  * @author Mwikala Kangwa <support@mwikala.co.uk>
  * @since 1.0
  */
-class Volume extends FlysystemVolume
+class Fs extends FlysystemFs
 {
     // Constants
     // =========================================================================
@@ -100,63 +101,45 @@ class Volume extends FlysystemVolume
      */ #
     public $contentDisposition = '';
 
-    // Getters
-    // =========================================================================
-
-    public function getSubfolder()
-    {
-        return Craft::parseEnv($this->subfolder);
-    }
-
-    public function getKeyId()
-    {
-        return Craft::parseEnv($this->keyId);
-    }
-
-    public function getSecret()
-    {
-        return Craft::parseEnv($this->secret);
-    }
-
-    public function getEndpoint()
-    {
-        return Craft::parseEnv($this->endpoint);
-    }
-
-    public function getBucket()
-    {
-        return Craft::parseEnv($this->bucket);
-    }
-
-    public function getRegion()
-    {
-        return Craft::parseEnv($this->region);
-    }
-
     // Public Methods
     // =========================================================================
 
     /**
      * @inheritdoc
      */
-    public function rules()
+    public function behaviors(): array
     {
-        $rules = parent::rules();
-        $rules[] = [['keyId', 'secret', 'region', 'bucket', 'endpoint'], 'required'];
+        $behaviors = parent::behaviors();
+        $behaviors['parser'] = [
+            'class' => EnvAttributeParserBehavior::class,
+            'attributes' => [
+                'subfolder', 'keyId', 'secret', 'region', 'bucket', 'endpoint'
+            ],
+        ];
 
-        return $rules;
+        return $behaviors;
     }
 
     /**
      * @inheritdoc
      */
-    public function getSettingsHtml()
+    protected function defineRules(): array
     {
-        return Craft::$app->getView()->renderTemplate('linode-s3/volumeSettings', [
-            'volume' => $this,
+        return array_merge(parent::defineRules(), [
+            [['keyId', 'secret', 'region', 'bucket', 'endpoint'], 'required'],
+        ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSettingsHtml(): ?string
+    {
+        return Craft::$app->getView()->renderTemplate('linode-s3/fsSettings', [
+            'fs' => $this,
             'periods' => array_merge(['' => ''], Assets::periodList()),
             'contentDispositionOptions' => [
-                '' => '--- none ---',
+                '' => 'none',
                 'inline' => 'inline',
                 'attachment' => 'attachment'
             ],
@@ -167,9 +150,9 @@ class Volume extends FlysystemVolume
     /**
      * @inheritdoc
      */
-    public function getRootUrl()
+    public function getRootUrl(): ?string
     {
-        if (($rootUrl = parent::getRootUrl()) !== false && $this->getSubfolder()) {
+        if (($rootUrl = parent::getRootUrl()) !== false && $this->_subfolder()) {
             $rootUrl .= rtrim($this->getSubfolder(), '/') . '/';
         }
         return $rootUrl;
@@ -182,23 +165,34 @@ class Volume extends FlysystemVolume
      * @inheritdoc
      * @return AwsS3Adapter
      */
-    protected function createAdapter()
+    protected function createAdapter(): FilesystemAdapter
     {
-        $config = $this->_getConfigArray();
+        $client = static::client($this->_getConfigArray(), $this->_getCredentials());
 
-        $client = static::client($config);
-
-        return new AwsS3Adapter($client, $this->getBucket(), $this->getSubfolder(), [], false);
+        return new AwsS3V3Adapter($client, App::parseEnv($this->bucket), $this->_subfolder(), null, null, [], false);
     }
 
     /**
      * Get the Amazon S3 Client
-     * 
+     *
      * @param $config
      * @return S3Client
      */
-    protected static function client(array $config = []): S3Client
+    protected static function client(array $config = [], array $credentials = []): S3Client
     {
+        if (!empty($config['credentials']) && $config['credentials'] instanceof Credentials) {
+            $config['generateNewConfig'] = static function() use ($credentials) {
+                $args = [
+                    $credentials['keyId'],
+                    $credentials['secret'],
+                    $credentials['region'],
+                    true,
+                ];
+
+                return call_user_func_array(self::class . '::buildConfigArray', $args);
+            };
+        }
+
         return new S3Client($config);
     }
 
@@ -211,7 +205,7 @@ class Volume extends FlysystemVolume
             $expires = new DateTime();
             $now = new DateTime();
             $expires->modify('+' . $this->expires);
-            $diff = $expires->format('U') - $now->format('U');
+            $diff = (int) $expires->format('U') - (int) $now->format('U');
             $config['CacheControl'] = 'max-age=' . $diff . ', must-revalidate';
             $config['ContentDisposition'] = $this->contentDisposition;
         }
@@ -223,23 +217,34 @@ class Volume extends FlysystemVolume
     // =========================================================================
 
     /**
+     * Returns the parsed subfolder path
+     *
+     * @return string
+     */
+    private function _subfolder(): string
+    {
+        if ($this->subfolder && ($subfolder = rtrim(App::parseEnv($this->subfolder), '/')) !== '') {
+            return $subfolder . '/';
+        }
+
+        return '';
+    }
+
+    /**
      * Get the config array for AWS client
-     * 
+     *
      * @return array
      */
     private function _getConfigArray()
     {
-        $keyId = $this->getKeyId();
-        $secret = $this->getSecret();
-        $region = $this->getRegion();
-        $endpoint = $this->getEndpoint();
+        $credentials = $this->_getCredentials();
 
-        return self::_buildConfigArray($keyId, $secret, $region, $endpoint);
+        return self::_buildConfigArray($credentials['keyId'], $credentials['secret'], $credentials['region'], $credentials['endpoint']);
     }
 
     /**
      * Built the config array
-     * 
+     *
      * @param $keyId
      * @param $secret
      * @param $region
@@ -252,15 +257,36 @@ class Volume extends FlysystemVolume
             'region' => $region,
             'endpoint' => $endpoint,
             'version' => 'latest',
-            'credentials' => new Credentials(
-                $keyId,
-                $secret
-            ),
+            'credentials' => [
+                'key' => $keyId,
+                'secret' => $secret,
+            ],
         ];
 
         $client = Craft::createGuzzleClient();
         $config['http_handler'] = new GuzzleHandler($client);
 
         return $config;
+    }
+
+    /**
+     * Return the credentials as an array
+     *
+     * @return array
+     */
+    private function _getCredentials(): array
+    {
+        return [
+            'keyId' => App::parseEnv($this->keyId),
+            'secret' => App::parseEnv($this->secret),
+            'region' => App::parseEnv($this->region),
+            'endpoint' => App::parseEnv($this->endpoint),
+        ];
+    }
+
+    /** @inheritdoc */
+    protected function invalidateCdnPath(string $path): bool
+    {
+        return true;
     }
 }

--- a/src/LinodeS3Bundle.php
+++ b/src/LinodeS3Bundle.php
@@ -13,7 +13,7 @@ class LinodeS3Bundle extends AssetBundle
     /**
      * @inheritdoc
      */
-    public function init()
+    public function init(): void
     {
         $this->sourcePath = '@mwikala/linodes3/resources';
 
@@ -22,7 +22,7 @@ class LinodeS3Bundle extends AssetBundle
         ];
 
         $this->js = [
-            'js/editVolume.js'
+            'js/editFilesystem.js'
         ];
 
         parent::init();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -3,13 +3,13 @@
 namespace mwikala\linodes3;
 
 use craft\events\RegisterComponentTypesEvent;
-use craft\services\Volumes;
+use craft\services\Fs as FsService;
 use yii\base\Event;
 
 
 /**
  * Plugin represents the Linode S3 volume plugin
- * 
+ *
  * @author Mwikala Kangwa <support@mwikala.co.uk>
  * @since 3.4
  */
@@ -19,12 +19,12 @@ class Plugin extends \craft\base\Plugin
     /**
      * @inheritdoc
      */
-    public function init()
+    public function init(): void
     {
         parent::init();
 
-        Event::on(Volumes::class, Volumes::EVENT_REGISTER_VOLUME_TYPES, function(RegisterComponentTypesEvent $event) {
-            $event->types[] = Volume::class;
+        Event::on(FsService::class, FsService::EVENT_REGISTER_FILESYSTEM_TYPES, static function (RegisterComponentTypesEvent $event) {
+            $event->types[] = Fs::class;
         });
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -10,7 +10,7 @@ use yii\base\Event;
 /**
  * Plugin represents the Linode S3 volume plugin
  *
- * @author Mwikala Kangwa <support@mwikala.co.uk>
+ * @author Mwikala Kangwa <hello@mwikala.co.uk>
  * @since 3.4
  */
 class Plugin extends \craft\base\Plugin

--- a/src/migrations/m220725_123900_update_linode_volume_to_filesystem.php
+++ b/src/migrations/m220725_123900_update_linode_volume_to_filesystem.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace mwikala\linodes3\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\services\ProjectConfig;
+use mwikala\linodes3\Fs;
+
+class m220725_123900_update_linode_volume_to_filesystem extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $projectConfig = Craft::$app->getProjectConfig();
+
+        $schemaVersion = $projectConfig->get('plugins.linodes3.schemaVersion', true);
+        if (version_compare($schemaVersion, '2.0', '>=')) {
+            return true;
+        }
+
+        $fsConfigs = $projectConfig->get(ProjectConfig::PATH_FS) ?? [];
+        foreach ($fsConfigs as $uid => $config) {
+            if ($config['type'] === 'mwikala\linodes3\Volume') {
+                $config['type'] = Fs::class;
+                $projectConfig->set(sprintf('%s.%s', ProjectConfig::PATH_FS, $uid), $config);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m220725_123900_update_linode_volume_to_filesystem cannot be reverted." . PHP_EOL;
+        return false;
+    }
+}

--- a/src/resources/js/editFilesystem.js
+++ b/src/resources/js/editFilesystem.js
@@ -1,5 +1,5 @@
 $(document).ready(function () {
-    var spacesChangeExpiryValue = function () {
+    var ls3ChangeExpiryValue = function () {
         var parent = $(this).parents('.field'),
             amount = parent.find('.ls3-expires-amount').val(),
             period = parent.find('.ls3-expires-period select').val();
@@ -9,6 +9,6 @@ $(document).ready(function () {
         parent.find('[type=hidden]').val(combinedValue);
     };
 
-    $('.ls3-expires-amount').keyup(spacesChangeExpiryValue).change(spacesChangeExpiryValue);
-    $('.ls3-expires-period select').change(spacesChangeExpiryValue);
+    $('.ls3-expires-amount').keyup(ls3ChangeExpiryValue).change(ls3ChangeExpiryValue);
+    $('.ls3-expires-period select').change(ls3ChangeExpiryValue);
 });

--- a/src/templates/fsSettings.html
+++ b/src/templates/fsSettings.html
@@ -1,14 +1,14 @@
 {% import "_includes/forms" as forms %}
 
 {{ forms.autosuggestField({
-    label: "Access Key"|t('linode-s3'),
+    label: "Access Key ID"|t('linode-s3'),
     id: 'keyId',
     class: 'ltr',
     name: 'keyId',
     suggestEnvVars: true,
     suggestAliases: true,
-    value: (volume is defined ? volume.keyId : null),
-    errors: (volume is defined ? volume.getErrors('keyId') : null),
+    value: (fs is defined ? fs.keyId : null),
+    errors: (fs is defined ? fs.getErrors('keyId') : null),
     required: true,
 }) }}
 
@@ -19,8 +19,8 @@
     name: 'secret',
     suggestEnvVars: true,
     suggestAliases: true,
-    value: (volume is defined ? volume.secret : null),
-    errors: (volume is defined ? volume.getErrors('secret') : null),
+    value: (fs is defined ? fs.secret : null),
+    errors: (fs is defined ? fs.getErrors('secret') : null),
     required: true,
 }) }}
 
@@ -31,8 +31,8 @@
     name: 'endpoint',
     suggestEnvVars: true,
     suggestAliases: true,
-    value: (volume is defined ? volume.endpoint : null),
-    errors: (volume is defined ? volume.getErrors('endpoint') : null),
+    value: (fs is defined ? fs.endpoint : null),
+    errors: (fs is defined ? fs.getErrors('endpoint') : null),
     required: true,
 }) }}
 
@@ -43,8 +43,8 @@
     name: 'region',
     suggestEnvVars: true,
     suggestAliases: true,
-    value: (volume is defined ? volume.region : null),
-    errors: (volume is defined ? volume.getErrors('region') : null),
+    value: (fs is defined ? fs.region : null),
+    errors: (fs is defined ? fs.getErrors('region') : null),
     required: true,
     placeholder: "ams3"|t('linode-s3')
 }) }}
@@ -56,22 +56,22 @@
     name: 'bucket',
     suggestEnvVars: true,
     suggestAliases: true,
-    value: (volume is defined ? volume.bucket : null),
-    errors: (volume is defined ? volume.getErrors('bucket') : null),
+    value: (fs is defined ? fs.bucket : null),
+    errors: (fs is defined ? fs.getErrors('bucket') : null),
     required: true,
     placeholder: "your-bucket-name"|t('linode-s3')
 }) }}
 
 {{ forms.autosuggestField({
     label: "Subfolder"|t('linode-s3'),
-    instructions: "If you want to use a bucket’s subfolder as a Volume, specify the path to use here."|t('linode-s3'),
+    instructions: "If you want to use a bucket's subfolder as a File System, specify the path to use here."|t('linode-s3'),
     id: 'subfolder',
     class: 'ltr',
     name: 'subfolder',
     suggestEnvVars: true,
     suggestAliases: true,
-    value: (volume is defined ? volume.subfolder : null),
-    errors: (volume is defined ? volume.getErrors('subfolder') : null),
+    value: (fs is defined ? fs.subfolder : null),
+    errors: (fs is defined ? fs.getErrors('subfolder') : null),
     required: false,
     placeholder: "path/to/subfolder"|t('linode-s3')
 }) }}
@@ -79,7 +79,7 @@
 <hr>
 
 {% set cacheInput %}
-{% set expires = (volume.expires|length > 0 ? volume.expires|split(' ') : ['', ''])%}
+{% set expires = (fs.expires|length > 0 ? fs.expires|split(' ') : ['', ''])%}
 
 <div class="flex">
     <div>
@@ -99,7 +99,7 @@
 </div>
 {{ forms.hidden({
         name: "expires",
-        value: volume.expires,
+        value: fs.expires,
         class: "expires-combined"
     }) }}
 {% endset %}


### PR DESCRIPTION
This PR makes this plugin compatiable with Craft 4's new filesystem for assets as it moves 
away from Craft 3's "Volumes".

Closes #4
