### PR TITLE
Fixed bug where a call was made to Fs::getSubFolder 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.1 - 2022-08-10
+- Fixed bug where a call was made to Fs::getSubFolder (Method was removed in 2.0.0)
+
 ## 2.0.0 - 2022-07-25
 - Added support for Craft 4.
 

--- a/src/Fs.php
+++ b/src/Fs.php
@@ -153,7 +153,7 @@ class Fs extends FlysystemFs
     public function getRootUrl(): ?string
     {
         if (($rootUrl = parent::getRootUrl()) !== false && $this->_subfolder()) {
-            $rootUrl .= rtrim($this->getSubfolder(), '/') . '/';
+            $rootUrl .= rtrim($this->_subfolder(), '/') . '/';
         }
         return $rootUrl;
     }


### PR DESCRIPTION
You removed the getSubFolder method in 2.0.0 in favour of _subfolder (it seems), but this reference to it still exists, causing a fatal.

I've simply replaced the reference with the correct reference, added a changelog item and bumped the composer version.

I believe you will just need to publish a tag to get this fix out in the wild. 