### PR TITLE
Release 2.1.0: Improve Linode Object Storage support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.1.0 - 2026-07-18
+- Added Craft CMS 5 compatibility updates while retaining Craft CMS 4 support.
+- Updated dependency constraints to stable Craft CMS 4/5 and Craft Flysystem releases.
+- Updated the filesystem implementation to use strict types, typed properties, and the current AWS SDK Guzzle handler when available.
+- Added a Linode-aware S3 adapter that omits unsupported object ACL operations while preserving multipart uploads and MIME type detection.
+- Added the missing Content-Disposition setting field to the filesystem settings UI.
+- Improved Linode-specific setup guidance and endpoint examples in the control panel and README.
+- Fixed the Craft 3 volume-to-filesystem migration schema-version lookup to use the plugin handle.
+
 ## 2.0.1 - 2022-08-10
 - Fixed bug where a call was made to Fs::getSubFolder (Method was removed in 2.0.0)
 

--- a/README.md
+++ b/README.md
@@ -2,65 +2,96 @@
 
 <h1 align="center">Linode Object Storage for Craft CMS</h1>
 
-This plugin provides a [Linode Object Storage](https://www.linode.com/products/object-storage/) integration for [Craft CMS](https://craftcms.com/).
+This plugin provides a [Linode Object Storage](https://www.linode.com/products/object-storage/) filesystem for [Craft CMS](https://craftcms.com/).
 
 ## Requirements
 
-This plugin requires Craft CMS 4 or later.
+- Craft CMS 4.0+ or 5.0+
+- PHP 8.0.2+
+- PHP 8.2+ when running Craft CMS 5
 
 ## Installation
 
-You can install this plugin from the Plugin Store or with Composer.
-
-#### From the Plugin Store
-
-Go to the Plugin Store in your project’s Control Panel and search for “Linode Object Storage”. Then click on the “Install” button in its modal window.
-
-#### With Composer
-
-Open your terminal and run the following commands:
+Install the plugin from the Plugin Store, or with Composer:
 
 ```bash
-# go to the project directory
-cd /path/to/my-project.test
-
-# tell Composer to load the plugin
+cd /path/to/my-craft-project
 composer require mwikala/linode-s3
-
-# tell Craft to install the plugin
-./craft plugin/install linode-s3
+php craft plugin/install linode-s3
 ```
+
+The Composer package name is `mwikala/linode-s3` and the Craft plugin handle is `linode-s3`.
 
 ## Setup
 
-To create a new asset file system for your Amazon S3 bucket, go to Settings → Filesystems, create a new filesystem, and set the Filesystem Type setting to “Linode S3”.
+1. In Linode Cloud Manager, create an Object Storage bucket and an access key with access to that bucket.
+2. In Craft, go to Settings → Filesystems and create a new filesystem.
+3. Set **Filesystem Type** to **Linode Object Storage**.
+4. Enter your bucket details, or use environment variables such as `$LINODE_S3_BUCKET`.
+5. If files should be publicly accessible, enable **Files in this filesystem have public URLs** and set **Base URL** to the bucket URL or CDN/custom-domain URL.
+
+Linode bucket URLs usually look like this:
+
+```text
+https://[bucket-name].[region].linodeobjects.com
+```
+
+The plugin’s **API Endpoint** setting should be the same URL without the bucket name:
+
+```text
+https://[region].linodeobjects.com
+```
+
+For example, a bucket URL of `https://assets.eu-central-1.linodeobjects.com` would use:
+
+| Setting | Value |
+| --- | --- |
+| API Endpoint | `https://eu-central-1.linodeobjects.com` |
+| Region | `eu-central-1` |
+| Bucket | `assets` |
+| Base URL | `https://assets.eu-central-1.linodeobjects.com` |
+
+If you set a **Subfolder**, don’t append it to the **Base URL**. Craft adds the subfolder automatically when generating asset URLs.
 
 ## Environment Variables
 
-To allow you to setup different Buckets for different environments, you can set these handy environment variables in your `.env` and `.env.example` (so you don't forget them after pushing to source control):
+You can keep credentials and environment-specific bucket details in your project’s `.env` file:
 
 ```env
-# The Linode Object Storage Access Key with read/write access to Buckets
+# Linode Object Storage access key with read/write access to the bucket
 LINODE_S3_ACCESS_KEY=
 
-# The Linode Object Storage Access Secret
+# Linode Object Storage secret key
 LINODE_S3_SECRET=
 
-# THE URL endpoint for your Buckets
+# API endpoint, e.g. https://eu-central-1.linodeobjects.com
 LINODE_S3_ENDPOINT=
 
-# The region your Object Storage bucket is in
+# Region, e.g. eu-central-1
 LINODE_S3_REGION=
 
-# The name of your bucket
+# Bucket name, e.g. assets
 LINODE_S3_BUCKET=
 
-# The URL of the bucket
+# Public bucket, CDN, or custom-domain URL
 LINODE_S3_BUCKET_URL=
 ```
 
+Then use these values in the filesystem settings:
+
+| Setting | Value |
+| --- | --- |
+| API Endpoint | `$LINODE_S3_ENDPOINT` |
+| Region | `$LINODE_S3_REGION` |
+| Bucket | `$LINODE_S3_BUCKET` |
+| Access Key ID | `$LINODE_S3_ACCESS_KEY` |
+| Secret Access Key | `$LINODE_S3_SECRET` |
+| Base URL | `$LINODE_S3_BUCKET_URL` |
+
+Do not commit real access keys or secrets to source control.
+
 ## License & Support
 
-This plugin is released under the [MIT license](./LICENSE.md), meaning you can do whatever you please with it.
+This plugin is released under the [MIT license](./LICENSE.md).
 
-> If you experience any issues with the plugin then open an issue here and I'll try get it fixed/answered whenever I have some free time
+If you experience any issues with the plugin, please open an issue on GitHub and I’ll try to get it fixed or answered when I have some free time.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "mwikala/linode-s3",
     "description": "This plugin provides Linode Object Storage integration for Craft CMS",
     "type": "craft-plugin",
-    "version": "2.0.2",
     "keywords": [
         "aws",
         "assets",
@@ -26,13 +25,13 @@
         "email": "hello@mwikala.co.uk",
         "issues": "https://github.com/mwikala/linode-s3/issues?state=open",
         "source": "https://github.com/mwikala/linode-s3",
-        "docs": "https://github.com/mwikala/linode-s3/blob/master/README.md",
-        "rss": "https://github.com/mwikala/linode-s3/commits/master.atom"
+        "docs": "https://github.com/mwikala/linode-s3/blob/main/README.md",
+        "rss": "https://github.com/mwikala/linode-s3/commits/main.atom"
     },
     "require": {
-        "php": "^8.0",
-        "craftcms/cms": "^4.0.0-beta.4 | ^5.0.0",
-        "craftcms/flysystem": "^1.0.0-beta.2 | ^2.0.0",
+        "php": "^8.0.2",
+        "craftcms/cms": "^4.0.0|^5.0.0",
+        "craftcms/flysystem": "^1.0.2|^2.0.1",
         "league/flysystem-aws-s3-v3": "^3.0.0"
     },
     "autoload": {
@@ -44,7 +43,7 @@
         "name": "Linode Object Storage",
         "handle": "linode-s3",
         "schemaVersion": "2.0.0",
-        "documentationUrl": "https://github.com/mwikala/linode-s3/blob/master/README.md"
+        "documentationUrl": "https://github.com/mwikala/linode-s3/blob/main/README.md"
     },
     "config": {
         "allow-plugins": {

--- a/src/Fs.php
+++ b/src/Fs.php
@@ -1,22 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace mwikala\linodes3;
 
-use Craft;
-use DateTime;
 use Aws\S3\S3Client;
+use Craft;
+use craft\behaviors\EnvAttributeParserBehavior;
+use craft\flysystem\base\FlysystemFs;
 use craft\helpers\App;
 use craft\helpers\Assets;
-use Aws\Credentials\Credentials;
 use craft\helpers\DateTimeHelper;
-use craft\flysystem\base\FlysystemFs;
-use Aws\Handler\GuzzleV6\GuzzleHandler;
+use DateTime;
 use League\Flysystem\FilesystemAdapter;
-use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
-use craft\behaviors\EnvAttributeParserBehavior;
 
 /**
- * Class Fs
+ * Linode Object Storage filesystem.
  *
  * @property mixed $settingsHtml
  * @property string $rootUrl
@@ -28,19 +27,19 @@ class Fs extends FlysystemFs
     // Constants
     // =========================================================================
 
-    const STORAGE_STANDARD = 'STANDARD';
-    const STORAGE_REDUCE_REDUNDANCY = 'REDUCE_REDUNDANCY';
-    const STORAGE_STANDARD_IA = 'STANDARD_IA';
+    public const STORAGE_STANDARD = 'STANDARD';
+    public const STORAGE_REDUCED_REDUNDANCY = 'REDUCED_REDUNDANCY';
+    public const STORAGE_STANDARD_IA = 'STANDARD_IA';
 
     /**
-     * Cache key to use for caching purposes
+     * Cache key to use for caching purposes.
      */
-    const CACHE_KEY_PREFIX = 'linode.';
+    public const CACHE_KEY_PREFIX = 'linode.';
 
     /**
-     * Cache duration for access token
+     * Cache duration for access token.
      */
-    const CACHE_DURATION_SECONDS = 3600;
+    public const CACHE_DURATION_SECONDS = 3600;
 
     // Static
     // =========================================================================
@@ -50,7 +49,7 @@ class Fs extends FlysystemFs
      */
     public static function displayName(): string
     {
-        return 'Linode S3';
+        return 'Linode Object Storage';
     }
 
     // Properties
@@ -59,47 +58,47 @@ class Fs extends FlysystemFs
     /**
      * @var bool Whether this is a local source or not. Defaults to false.
      */
-    protected $isVolumeLocal = false;
+    protected bool $isVolumeLocal = false;
 
     /**
-     * @var string Subfolder to use
+     * @var string Subfolder to use.
      */
-    public $subfolder = '';
+    public string $subfolder = '';
 
     /**
-     * @var string Access Key id
+     * @var string Access key ID.
      */
-    public $keyId = '';
+    public string $keyId = '';
 
     /**
-     * @var string Secret Key
+     * @var string Secret access key.
      */
-    public $secret = '';
+    public string $secret = '';
 
     /**
-     * @var string Linode endpoint
+     * @var string Linode Object Storage API endpoint.
      */
-    public $endpoint = '';
+    public string $endpoint = '';
 
     /**
-     * @var string Bucket to use
+     * @var string Bucket to use.
      */
-    public $bucket = '';
+    public string $bucket = '';
 
     /**
-     * @var string Region to use
+     * @var string Region to use.
      */
-    public $region = '';
+    public string $region = '';
 
     /**
-     * @var string Cache expiration period
+     * @var string Cache expiration period.
      */
-    public $expires = '';
+    public string $expires = '';
 
     /**
-     * @var string Content Disposition value
-     */ #
-    public $contentDisposition = '';
+     * @var string Content-Disposition value.
+     */
+    public string $contentDisposition = '';
 
     // Public Methods
     // =========================================================================
@@ -113,7 +112,12 @@ class Fs extends FlysystemFs
         $behaviors['parser'] = [
             'class' => EnvAttributeParserBehavior::class,
             'attributes' => [
-                'subfolder', 'keyId', 'secret', 'region', 'bucket', 'endpoint'
+                'subfolder',
+                'keyId',
+                'secret',
+                'endpoint',
+                'bucket',
+                'region',
             ],
         ];
 
@@ -141,9 +145,9 @@ class Fs extends FlysystemFs
             'contentDispositionOptions' => [
                 '' => 'none',
                 'inline' => 'inline',
-                'attachment' => 'attachment'
+                'attachment' => 'attachment',
             ],
-            'contentDisposition' => $this->contentDisposition
+            'contentDisposition' => $this->contentDisposition,
         ]);
     }
 
@@ -155,6 +159,7 @@ class Fs extends FlysystemFs
         if (($rootUrl = parent::getRootUrl()) !== false && $this->_subfolder()) {
             $rootUrl .= rtrim($this->_subfolder(), '/') . '/';
         }
+
         return $rootUrl;
     }
 
@@ -163,36 +168,30 @@ class Fs extends FlysystemFs
 
     /**
      * @inheritdoc
-     * @return AwsS3Adapter
+     * @return LinodeS3V3Adapter
      */
     protected function createAdapter(): FilesystemAdapter
     {
-        $client = static::client($this->_getConfigArray(), $this->_getCredentials());
+        $client = static::client($this->_getConfigArray());
 
-        return new AwsS3V3Adapter($client, App::parseEnv($this->bucket), $this->_subfolder(), null, null, [], false);
+        return new LinodeS3V3Adapter(
+            $client,
+            App::parseEnv($this->bucket),
+            $this->_subfolder(),
+            null,
+            null,
+            [],
+            false,
+        );
     }
 
     /**
-     * Get the Amazon S3 Client
+     * Get the S3-compatible client.
      *
-     * @param $config
-     * @return S3Client
+     * @param array $config client config
      */
-    protected static function client(array $config = [], array $credentials = []): S3Client
+    protected static function client(array $config = []): S3Client
     {
-        if (!empty($config['credentials']) && $config['credentials'] instanceof Credentials) {
-            $config['generateNewConfig'] = static function() use ($credentials) {
-                $args = [
-                    $credentials['keyId'],
-                    $credentials['secret'],
-                    $credentials['region'],
-                    true,
-                ];
-
-                return call_user_func_array(self::class . '::buildConfigArray', $args);
-            };
-        }
-
         return new S3Client($config);
     }
 
@@ -205,21 +204,35 @@ class Fs extends FlysystemFs
             $expires = new DateTime();
             $now = new DateTime();
             $expires->modify('+' . $this->expires);
-            $diff = (int) $expires->format('U') - (int) $now->format('U');
-            $config['CacheControl'] = 'max-age=' . $diff . ', must-revalidate';
+            $diff = (int)$expires->format('U') - (int)$now->format('U');
+            $config['CacheControl'] = 'max-age=' . $diff;
+        }
+
+        if (!empty($this->contentDisposition)) {
             $config['ContentDisposition'] = $this->contentDisposition;
         }
 
-        return parent::addFileMetadataToConfig($config);
+        // Linode Object Storage doesn't support S3 object ACL headers like x-amz-acl.
+        // Craft's base Flysystem implementation adds visibility metadata, which the
+        // AWS S3 adapter translates into those ACL headers, so return our metadata
+        // directly and leave object access control to the bucket's Linode settings.
+        return $config;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function invalidateCdnPath(string $path): bool
+    {
+        // Not implemented; Linode Object Storage doesn't provide a first-party CDN purge API here.
+        return true;
     }
 
     // Private Methods
     // =========================================================================
 
     /**
-     * Returns the parsed subfolder path
-     *
-     * @return string
+     * Returns the parsed subfolder path.
      */
     private function _subfolder(): string
     {
@@ -231,27 +244,24 @@ class Fs extends FlysystemFs
     }
 
     /**
-     * Get the config array for AWS client
-     *
-     * @return array
+     * Get the config array for AWS clients.
      */
-    private function _getConfigArray()
+    private function _getConfigArray(): array
     {
         $credentials = $this->_getCredentials();
 
-        return self::_buildConfigArray($credentials['keyId'], $credentials['secret'], $credentials['region'], $credentials['endpoint']);
+        return self::_buildConfigArray(
+            $credentials['keyId'],
+            $credentials['secret'],
+            $credentials['region'],
+            $credentials['endpoint'],
+        );
     }
 
     /**
-     * Built the config array
-     *
-     * @param $keyId
-     * @param $secret
-     * @param $region
-     * @param $endpoint
-     * @return array
+     * Build the config array.
      */
-    private static function _buildConfigArray($keyId = null, $secret = null, $region = null, $endpoint = null): array
+    private static function _buildConfigArray(?string $keyId = null, ?string $secret = null, ?string $region = null, ?string $endpoint = null): array
     {
         $config = [
             'region' => $region,
@@ -264,15 +274,15 @@ class Fs extends FlysystemFs
         ];
 
         $client = Craft::createGuzzleClient();
-        $config['http_handler'] = new GuzzleHandler($client);
+        $config['http_handler'] = class_exists('Aws\\Handler\\Guzzle\\GuzzleHandler')
+            ? new \Aws\Handler\Guzzle\GuzzleHandler($client)
+            : new \Aws\Handler\GuzzleV6\GuzzleHandler($client);
 
         return $config;
     }
 
     /**
-     * Return the credentials as an array
-     *
-     * @return array
+     * Return the credentials as an array.
      */
     private function _getCredentials(): array
     {
@@ -282,11 +292,5 @@ class Fs extends FlysystemFs
             'region' => App::parseEnv($this->region),
             'endpoint' => App::parseEnv($this->endpoint),
         ];
-    }
-
-    /** @inheritdoc */
-    protected function invalidateCdnPath(string $path): bool
-    {
-        return true;
     }
 }

--- a/src/LinodeS3Bundle.php
+++ b/src/LinodeS3Bundle.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace mwikala\linodes3;
 
 use craft\web\AssetBundle;
 use craft\web\assets\cp\CpAsset;
 
 /**
- * Asset bundle for the Dashboard
+ * Asset bundle for the Linode Object Storage filesystem settings.
  */
 class LinodeS3Bundle extends AssetBundle
 {
@@ -22,7 +24,7 @@ class LinodeS3Bundle extends AssetBundle
         ];
 
         $this->js = [
-            'js/editFilesystem.js'
+            'js/editFilesystem.js',
         ];
 
         parent::init();

--- a/src/LinodeS3V3Adapter.php
+++ b/src/LinodeS3V3Adapter.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mwikala\linodes3;
+
+use Aws\S3\S3ClientInterface;
+use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
+use League\Flysystem\Config;
+use League\Flysystem\FileAttributes;
+use League\Flysystem\UnableToCopyFile;
+use League\Flysystem\UnableToMoveFile;
+use League\Flysystem\UnableToSetVisibility;
+use League\Flysystem\UnableToWriteFile;
+use League\Flysystem\Visibility;
+use League\MimeTypeDetection\FinfoMimeTypeDetector;
+use League\MimeTypeDetection\MimeTypeDetector;
+use Throwable;
+
+/**
+ * Flysystem S3 adapter variant for Linode Object Storage.
+ *
+ * Linode's S3-compatible API does not implement object ACL operations, so this
+ * adapter avoids x-amz-acl headers and GetObjectAcl/PutObjectAcl calls.
+ */
+class LinodeS3V3Adapter extends AwsS3V3Adapter
+{
+    private const FORWARDED_OPTIONS = [
+        'CacheControl',
+        'ContentDisposition',
+        'ContentEncoding',
+        'ContentLength',
+        'ContentType',
+        'Expires',
+        'Metadata',
+        'MetadataDirective',
+        'RequestPayer',
+        'SSECustomerAlgorithm',
+        'SSECustomerKey',
+        'SSECustomerKeyMD5',
+        'SSEKMSKeyId',
+        'ServerSideEncryption',
+        'StorageClass',
+        'Tagging',
+        'WebsiteRedirectLocation',
+        'ChecksumAlgorithm',
+        'CopySourceSSECustomerAlgorithm',
+        'CopySourceSSECustomerKey',
+        'CopySourceSSECustomerKeyMD5',
+    ];
+
+    public function __construct(
+        private S3ClientInterface $linodeClient,
+        private string $linodeBucket,
+        private string $linodePrefix = '',
+        ?\League\Flysystem\AwsS3V3\VisibilityConverter $visibility = null,
+        ?MimeTypeDetector $mimeTypeDetector = null,
+        private array $linodeOptions = [],
+        bool $streamReads = true,
+    ) {
+        $this->mimeTypeDetector = $mimeTypeDetector ?? new FinfoMimeTypeDetector();
+
+        parent::__construct(
+            $linodeClient,
+            $linodeBucket,
+            $linodePrefix,
+            $visibility,
+            $this->mimeTypeDetector,
+            $linodeOptions,
+            $streamReads,
+        );
+    }
+
+    private MimeTypeDetector $mimeTypeDetector;
+
+    public function write(string $path, string $contents, Config $config): void
+    {
+        $this->upload($path, $contents, $config);
+    }
+
+    public function writeStream(string $path, $contents, Config $config): void
+    {
+        $this->upload($path, $contents, $config);
+    }
+
+    public function createDirectory(string $path, Config $config): void
+    {
+        $this->upload(rtrim($path, '/') . '/', '', $config);
+    }
+
+    public function copy(string $source, string $destination, Config $config): void
+    {
+        if ($source === $destination) {
+            return;
+        }
+
+        $arguments = array_merge($this->copyOptionsFromConfig($config), [
+            'Bucket' => $this->linodeBucket,
+            'Key' => $this->prefixPath($destination),
+            'CopySource' => sprintf('%s/%s', $this->linodeBucket, $this->prefixPath($source)),
+            'MetadataDirective' => $config->get('MetadataDirective', 'COPY'),
+        ]);
+
+        try {
+            $this->linodeClient->copyObject($arguments);
+        } catch (Throwable $exception) {
+            throw UnableToCopyFile::fromLocationTo($source, $destination, $exception);
+        }
+    }
+
+    public function move(string $source, string $destination, Config $config): void
+    {
+        if ($source === $destination) {
+            return;
+        }
+
+        try {
+            $this->copy($source, $destination, $config);
+            $this->delete($source);
+        } catch (Throwable $exception) {
+            throw UnableToMoveFile::fromLocationTo($source, $destination, $exception);
+        }
+    }
+
+    public function setVisibility(string $path, string $visibility): void
+    {
+        throw UnableToSetVisibility::atLocation($path, 'Linode Object Storage does not support object ACLs.');
+    }
+
+    public function visibility(string $path): FileAttributes
+    {
+        return new FileAttributes($path, null, Visibility::PRIVATE);
+    }
+
+    private function upload(string $path, $body, Config $config): void
+    {
+        $key = $this->prefixPath($path);
+        $options = $this->multipartOptionsFromConfig($config);
+
+        if (!isset($options['params']['ContentType']) && ($mimeType = $this->mimeTypeDetector->detectMimeType($key, $body))) {
+            $options['params']['ContentType'] = $mimeType;
+        }
+
+        try {
+            $this->linodeClient->upload($this->linodeBucket, $key, $body, null, $options);
+        } catch (Throwable $exception) {
+            throw UnableToWriteFile::atLocation($path, $exception->getMessage(), $exception);
+        }
+    }
+
+    private function multipartOptionsFromConfig(Config $config): array
+    {
+        $config = $config->withDefaults($this->linodeOptions);
+        $options = ['params' => []];
+
+        if ($mimetype = $config->get('mimetype')) {
+            $options['params']['ContentType'] = $mimetype;
+        }
+
+        foreach (self::FORWARDED_OPTIONS as $option) {
+            $value = $config->get($option, '__NOT_SET__');
+            if ($value !== '__NOT_SET__') {
+                $options['params'][$option] = $value;
+            }
+        }
+
+        foreach (AwsS3V3Adapter::MUP_AVAILABLE_OPTIONS as $option) {
+            $value = $config->get($option, '__NOT_SET__');
+            if ($value !== '__NOT_SET__') {
+                $options[$option] = $value;
+            }
+        }
+
+        return $options;
+    }
+
+    private function copyOptionsFromConfig(Config $config): array
+    {
+        $config = $config->withDefaults($this->linodeOptions);
+        $options = [];
+
+        foreach (self::FORWARDED_OPTIONS as $option) {
+            $value = $config->get($option, '__NOT_SET__');
+            if ($value !== '__NOT_SET__') {
+                $options[$option] = $value;
+            }
+        }
+
+        return $options;
+    }
+
+    private function prefixPath(string $path): string
+    {
+        return trim($this->linodePrefix . ltrim($path, '/'), '/');
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,21 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace mwikala\linodes3;
 
 use craft\events\RegisterComponentTypesEvent;
 use craft\services\Fs as FsService;
 use yii\base\Event;
 
-
 /**
- * Plugin represents the Linode S3 volume plugin
+ * Plugin represents the Linode Object Storage filesystem plugin.
  *
  * @author Mwikala Kangwa <hello@mwikala.co.uk>
  * @since 3.4
  */
 class Plugin extends \craft\base\Plugin
 {
-
     /**
      * @inheritdoc
      */
@@ -23,7 +23,7 @@ class Plugin extends \craft\base\Plugin
     {
         parent::init();
 
-        Event::on(FsService::class, FsService::EVENT_REGISTER_FILESYSTEM_TYPES, static function (RegisterComponentTypesEvent $event) {
+        Event::on(FsService::class, FsService::EVENT_REGISTER_FILESYSTEM_TYPES, static function(RegisterComponentTypesEvent $event): void {
             $event->types[] = Fs::class;
         });
     }

--- a/src/migrations/m220725_123900_update_linode_volume_to_filesystem.php
+++ b/src/migrations/m220725_123900_update_linode_volume_to_filesystem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace mwikala\linodes3\migrations;
 
 use Craft;
@@ -16,14 +18,15 @@ class m220725_123900_update_linode_volume_to_filesystem extends Migration
     {
         $projectConfig = Craft::$app->getProjectConfig();
 
-        $schemaVersion = $projectConfig->get('plugins.linodes3.schemaVersion', true);
-        if (version_compare($schemaVersion, '2.0', '>=')) {
+        $schemaVersion = $projectConfig->get('plugins.linode-s3.schemaVersion', true)
+            ?? $projectConfig->get('plugins.linodes3.schemaVersion', true);
+        if ($schemaVersion !== null && version_compare($schemaVersion, '2.0.0', '>=')) {
             return true;
         }
 
         $fsConfigs = $projectConfig->get(ProjectConfig::PATH_FS) ?? [];
         foreach ($fsConfigs as $uid => $config) {
-            if ($config['type'] === 'mwikala\linodes3\Volume') {
+            if (($config['type'] ?? null) === 'mwikala\\linodes3\\Volume') {
                 $config['type'] = Fs::class;
                 $projectConfig->set(sprintf('%s.%s', ProjectConfig::PATH_FS, $uid), $config);
             }

--- a/src/templates/fsSettings.html
+++ b/src/templates/fsSettings.html
@@ -1,39 +1,38 @@
 {% import "_includes/forms" as forms %}
 
-{{ forms.autosuggestField({
-    label: "Access Key ID"|t('linode-s3'),
-    id: 'keyId',
-    class: 'ltr',
-    name: 'keyId',
-    suggestEnvVars: true,
-    suggestAliases: true,
-    value: (fs is defined ? fs.keyId : null),
-    errors: (fs is defined ? fs.getErrors('keyId') : null),
-    required: true,
-}) }}
+<div class="readable">
+    <blockquote class="note tip">
+        <p>
+            In Linode Cloud Manager, open your Object Storage bucket and copy the bucket URL.<br>
+            The URL will look something like this:<br><br>
+
+            <strong>https://[bucket-name].[region].linodeobjects.com</strong><br><br>
+
+            The API Endpoint is this URL without the bucket name, like this:<br><br>
+
+            <strong>https://[region].linodeobjects.com</strong><br><br>
+
+            The “Region” and “Bucket” settings below are the corresponding <strong>[region]</strong> and <strong>[bucket-name]</strong> values.<br><br>
+
+            To set the “Base URL” above, enable the “Files in this filesystem have public URLs” lightswitch.
+            <strong>The value should be the whole bucket URL. Do not add the subfolder from the “Subfolder” setting below if you’ve configured one.</strong>
+        </p>
+    </blockquote>
+</div>
+
+<hr>
 
 {{ forms.autosuggestField({
-    label: "Access Secret"|t('linode-s3'),
-    id: 'secret',
-    class: 'ltr',
-    name: 'secret',
-    suggestEnvVars: true,
-    suggestAliases: true,
-    value: (fs is defined ? fs.secret : null),
-    errors: (fs is defined ? fs.getErrors('secret') : null),
-    required: true,
-}) }}
-
-{{ forms.autosuggestField({
-    label: "Endpoint"|t('linode-s3'),
+    label: "API Endpoint"|t('linode-s3'),
     id: 'endpoint',
     class: 'ltr',
     name: 'endpoint',
     suggestEnvVars: true,
     suggestAliases: true,
-    value: (fs is defined ? fs.endpoint : null),
-    errors: (fs is defined ? fs.getErrors('endpoint') : null),
+    value: fs.endpoint,
+    errors: fs.getErrors('endpoint'),
     required: true,
+    placeholder: "https://eu-central-1.linodeobjects.com"|t('linode-s3')
 }) }}
 
 {{ forms.autosuggestField({
@@ -43,10 +42,10 @@
     name: 'region',
     suggestEnvVars: true,
     suggestAliases: true,
-    value: (fs is defined ? fs.region : null),
-    errors: (fs is defined ? fs.getErrors('region') : null),
+    value: fs.region,
+    errors: fs.getErrors('region'),
     required: true,
-    placeholder: "ams3"|t('linode-s3')
+    placeholder: "eu-central-1"|t('linode-s3')
 }) }}
 
 {{ forms.autosuggestField({
@@ -56,48 +55,83 @@
     name: 'bucket',
     suggestEnvVars: true,
     suggestAliases: true,
-    value: (fs is defined ? fs.bucket : null),
-    errors: (fs is defined ? fs.getErrors('bucket') : null),
+    value: fs.bucket,
+    errors: fs.getErrors('bucket'),
     required: true,
     placeholder: "your-bucket-name"|t('linode-s3')
 }) }}
 
 {{ forms.autosuggestField({
     label: "Subfolder"|t('linode-s3'),
-    instructions: "If you want to use a bucket's subfolder as a File System, specify the path to use here."|t('linode-s3'),
+    instructions: "If you want to use a bucket’s subfolder as a filesystem, specify the path to use here."|t('linode-s3'),
     id: 'subfolder',
     class: 'ltr',
     name: 'subfolder',
     suggestEnvVars: true,
     suggestAliases: true,
-    value: (fs is defined ? fs.subfolder : null),
-    errors: (fs is defined ? fs.getErrors('subfolder') : null),
-    required: false,
+    value: fs.subfolder,
+    errors: fs.getErrors('subfolder'),
     placeholder: "path/to/subfolder"|t('linode-s3')
 }) }}
 
 <hr>
 
-{% set cacheInput %}
-{% set expires = (fs.expires|length > 0 ? fs.expires|split(' ') : ['', ''])%}
+<div class="readable">
+    <blockquote class="note tip">
+        <p>
+            Access Key ID and Secret Access Key can be created from Linode Cloud Manager under Object Storage → Access Keys.
+        </p>
+    </blockquote>
+</div>
 
-<div class="flex">
-    <div>
-        {{ forms.text({
+<hr>
+
+{{ forms.autosuggestField({
+    label: "Access Key ID"|t('linode-s3'),
+    id: 'keyId',
+    class: 'ltr',
+    name: 'keyId',
+    suggestEnvVars: true,
+    suggestAliases: true,
+    value: fs.keyId,
+    errors: fs.getErrors('keyId'),
+    required: true,
+}) }}
+
+{{ forms.autosuggestField({
+    label: "Secret Access Key"|t('linode-s3'),
+    id: 'secret',
+    class: 'ltr',
+    name: 'secret',
+    suggestEnvVars: true,
+    suggestAliases: true,
+    value: fs.secret,
+    errors: fs.getErrors('secret'),
+    required: true,
+}) }}
+
+<hr>
+
+{% set cacheInput %}
+    {% set expires = (fs.expires|length > 0 ? fs.expires|split(' ') : ['', ''])%}
+
+    <div class="flex">
+        <div>
+            {{ forms.text({
                 id: 'expiresAmount',
                 value: expires[0],
                 size: 2,
                 class: 'ls3-expires-amount'
             }) }}
-    </div>
-    {{ forms.select({
+        </div>
+        {{ forms.select({
             id: 'expiresPeriod',
             options: periods,
             value: expires[1],
             class: 'ls3-expires-period'
         }) }}
-</div>
-{{ forms.hidden({
+    </div>
+    {{ forms.hidden({
         name: "expires",
         value: fs.expires,
         class: "expires-combined"
@@ -110,5 +144,14 @@
     id: 'cacheDuration',
 }, cacheInput) }}
 
+{{ forms.selectField({
+    label: "Content Disposition"|t,
+    instructions: "The Content-Disposition header indicates whether content should be displayed inline in the browser or downloaded and saved locally."|t,
+    id: 'contentDisposition',
+    name: 'contentDisposition',
+    options: contentDispositionOptions,
+    value: contentDisposition,
+    class: 'ls3-content-disposition'
+}) }}
 
 {% do view.registerAssetBundle("mwikala\\linodes3\\LinodeS3Bundle") %}


### PR DESCRIPTION
## What changed

Version 2.1.0 updates the plugin for current Craft filesystem conventions while keeping Craft 4 support in place.

- Added a Linode-aware S3 adapter that avoids object ACL calls Linode Object Storage does not support, while retaining Flysystem multipart uploads and MIME-type detection. Uploads, copies, and moves now rely on the bucket’s own access settings instead of attempting unsupported per-object ACL changes.
- Updated the filesystem implementation for current AWS SDK handler compatibility and removed an unused credential-refresh path.
- Refined the settings screen with clearer endpoint, bucket, credential, cache, and Content-Disposition guidance.
- Clarified the README with current install instructions, environment-variable setup, and the distinction between a bucket URL and the regional API endpoint.
- Updated Craft/Flysystem dependency ranges for maintained Craft 4 and Craft 5 releases.
- Fixed the legacy volume-to-filesystem migration to look up the plugin’s actual handle, while retaining the old lookup as a fallback.
- Finalized the 2.1.0 changelog.

## Why

Linode Object Storage is S3-compatible but does not implement object ACL operations. The previous generic adapter path could turn normal Craft file actions into ACL requests that Linode rejects. This change keeps object access policy where Linode expects it: on the bucket.

For files with public URLs enabled, the bucket or the relevant prefix must still be publicly readable in Linode; that is what allows browser previews and public asset links to load.